### PR TITLE
feat(css): add max-height variable to CSS custom variables

### DIFF
--- a/src/css/variablesCustom.css
+++ b/src/css/variablesCustom.css
@@ -79,6 +79,7 @@
   --hr-border-width: 0 0 2px;
   --hr-secondary-border-bottom: 2px solid var(--color-secondary);
   --hr-secondary-opacity: 1;
+  --max-height: auto;
   --navigation-alnatura-a-link-line-height-mobile: 1.5;
   --navigation-alnatura-a-link-line-height: 1.5;
   --navigation-alnatura-color-mobile-custom: var(--navigation-alnatura-color-second-level-custom);


### PR DESCRIPTION
With `--max-height: auto;` we are able to keep the aspect ratio for mobile videos (9:16).

Just for my understanding:
Why was a `max-height` of `75 vh` [introduced for iframes](https://github.com/mits-gossau/web-components-toolbox/blob/master/src/es/components/atoms/iframe/Iframe.js#L81) in the first place?

Ticket
[MUTOBOTEAM-1999](https://jira.migros.net/browse/MUTOBOTEAM-1999)